### PR TITLE
Update s3 provider script to create recursive temp directories.

### DIFF
--- a/lib/puppet/provider/s3/s3.rb
+++ b/lib/puppet/provider/s3/s3.rb
@@ -60,7 +60,7 @@ Puppet::Type.type(:s3).provide(:s3) do
       if File.exists?(resource[:path])
 
           # Setup a temp file to compare against
-          temp_file = Tempfile.new(resource[:path])
+          temp_file = Tempfile.new(File.basename(resource[:path]), File.dirname(resource[:path]))
 
           # Create a new S3 client object
           s3 = Aws::S3::Client.new(


### PR DESCRIPTION
Got following error when running puppet only if the s3 file exist. 

> /S3[/opt/scripts/testfile.txt]: Could not evaluate: No such file or directory - /tmp/opt/scripts/testfile.txt20160510-17135-1div8bl

This is because s3.rb is using `Tempfile.new('file')` instead of `Tempfile.new('file', '/path/xyz/')`. 
